### PR TITLE
Redirect Post-Match Registrations

### DIFF
--- a/src/pages/Registration/RegistrationNew.tsx
+++ b/src/pages/Registration/RegistrationNew.tsx
@@ -497,8 +497,16 @@ const RegistrationNew = () => {
         shouldWaitlist = await runTransaction(db, async (transaction) => {
           const programSnap = await transaction.get(programStateRef);
           const programData = programSnap.data();
+          const matchesFinal = programData?.matches_final === true;
+          const programStarted = programData?.started === true;
           const current = programData?.currentParticipants ?? 0;
           const max = programData?.maxParticipants ?? Infinity;
+
+          // Once matches are finalized, keep all new registrations on waitlist
+          // until the program has started, regardless of participant capacity.
+          if (matchesFinal && !programStarted) {
+            return true;
+          }
 
           if (current >= max) {
             return true;


### PR DESCRIPTION
# Pull Request

## Description
Registrations are now automatically routed to the waitlist when matches are finalized but the program has not started yet.

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues (put task name here from Notion)
**Redirect Post-Match Registrations**
If all matches are finalized, but the program hasn’t started yet, all registrations should go to the waitlist. This should happen regardless of the currentParticipants and maxParticipants fields in the programState file

## Pre-Submission Checklist

### Code Review Preparation
- [x] I have performed a self-review and reviewed the changed files
- [x] My code follows the project's style guidelines and passes linting
- [x] I have added comments in hard-to-understand areas and updated documentation

### Testing
- [ ] I have added relevant tests and they pass locally
- [x] I have tested the changes manually, including edge cases

### Code Quality & Security
- [x] I have formatted my code and removed debugging/unused code
- [x] No TypeScript errors or linting issues
- [x] No sensitive information committed (API keys, passwords, etc.)
- [x] User inputs are validated and sanitized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registration logic to properly evaluate program state when determining waitlist placement during sign-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->