### PR TITLE
bcc-emails

### DIFF
--- a/src/pages/Dashboard/AdminCreator.tsx
+++ b/src/pages/Dashboard/AdminCreator.tsx
@@ -254,9 +254,9 @@ export default function AdminDashboard() {
     const emailList = list.map((u) => u.email).filter(Boolean);
 
     // Admin's email goes in "to:", participant/subadmin emails go in "bcc:"
-    const bccList = emailList.map((e) => encodeURIComponent(e)).join(",");
-    const adminEmail = encodeURIComponent(user?.email ?? "");
-    const mailto = `mailto:${adminEmail}?bcc=${encodeURIComponent(bccList)}`;
+    const bccList = emailList.join(",");
+    const adminEmail = user?.email ?? "";
+    const mailto = `mailto:${adminEmail}?bcc=${bccList}`;
     window.location.href = mailto;
   };
 

--- a/src/pages/Dashboard/AdminCreator.tsx
+++ b/src/pages/Dashboard/AdminCreator.tsx
@@ -254,9 +254,9 @@ export default function AdminDashboard() {
     const emailList = list.map((u) => u.email).filter(Boolean);
 
     // Admin's email goes in "to:", participant/subadmin emails go in "bcc:"
-    const bccList = emailList.join(",");
-    const adminEmail = user?.email ?? "";
-    const mailto = `mailto:${adminEmail}?bcc=${bccList}`;
+    const bccList = emailList.map((e) => encodeURIComponent(e)).join(",");
+    const adminEmail = encodeURIComponent(user?.email ?? "");
+    const mailto = `mailto:${adminEmail}?bcc=${encodeURIComponent(bccList)}`;
     window.location.href = mailto;
   };
 

--- a/src/pages/Dashboard/AdminCreator.tsx
+++ b/src/pages/Dashboard/AdminCreator.tsx
@@ -28,6 +28,7 @@ import type {
   FormResponse,
 } from "../../types";
 import ParticipantInfoPopup from "./components/ParticipantInfoPopup/ParticipantInfoPopup";
+import { useAuth } from "../../auth/AuthProvider";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type RoleFilter = "All" | Role | "Participant";
@@ -76,6 +77,7 @@ function composeDisplayName(doc: ParticipantDoc): string {
 
 // Main component for the Admin Dashboard page
 export default function AdminDashboard() {
+  const { user } = useAuth();
   const [admins, setAdmins] = useState<AdminRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -243,22 +245,18 @@ export default function AdminDashboard() {
     if (typeof window === "undefined") return;
 
     // Filters only participants and subadmins
-    const list = admins.filter((user) => {
-      const r = normaliseRole(user.role);
+    const list = admins.filter((u) => {
+      const r = normaliseRole(u.role);
       return r === "Participant" || r === "Subadmin";
     });
 
     // Holds all of the emails of the new list, filtering falsy emails
-    const emailList = list
-      .map((user) => {
-        return user.email;
-      })
-      .filter(Boolean);
+    const emailList = list.map((u) => u.email).filter(Boolean);
 
-    // Format the email list to be one string
-    const mailToEmailList = emailList.join(",");
-
-    const mailto = `mailto:${mailToEmailList}`;
+    // Admin's email goes in "to:", participant/subadmin emails go in "bcc:"
+    const bccList = emailList.join(",");
+    const adminEmail = user?.email ?? "";
+    const mailto = `mailto:${adminEmail}?bcc=${bccList}`;
     window.location.href = mailto;
   };
 


### PR DESCRIPTION
# Pull Request

## Description
Modified the "Contact All" button functionality on the Admin Dashboard to improve participant email privacy. Previously, clicking "Contact All" opened an email client with all participant and subadmin emails in the TO field, exposing everyone's email addresses to each other. Now, the logged-in admin's email address is placed in the TO field, while all participant and subadmin emails are added to the BCC field, ensuring recipients cannot see each other's email addresses.

**Changes made:**
- Added `useAuth` hook import to access the current authenticated user
- Added `const { user } = useAuth()` to retrieve the logged-in admin's email
- Updated [handleContactAll](cci:1://file:///Users/neelmokaria/Documents/Coding%20Projects/Projects/Hack4Impact/for-all-ages/src/pages/Dashboard/AdminCreator.tsx:242:2-260:4) function to:
  - Build BCC list from participant/subadmin emails
  - Use `user?.email` as the TO recipient
  - Construct mailto URL as `mailto:${adminEmail}?bcc=${bccList}`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues (put task name here from Notion)

## Pre-Submission Checklist

### Code Review Preparation
- [x] I have performed a self-review and reviewed the changed files
- [x] My code follows the project's style guidelines and passes linting
- [x] I have added comments in hard-to-understand areas and updated documentation

### Testing
- [ ] I have added relevant tests and they pass locally
- [x] I have tested the changes manually, including edge cases

### Code Quality & Security
- [x] I have formatted my code and removed debugging/unused code
- [x] No TypeScript errors or linting issues
- [x] No sensitive information committed (API keys, passwords, etc.)
- [x] User inputs are validated and sanitized

## Screenshots/Screen recording
**Test Steps:**
1. Log in as an admin user
2. Navigate to Admin Dashboard (Users page)
3. Click the "Contact All" button
4. Verify the mailto URL format in browser console: `mailto:admin@example.com?bcc=user1@...,user2@...`
5. Confirm email client opens with admin email in TO field and all participants in BCC field

## Additional Notes
- Only one file modified: [src/pages/Dashboard/AdminCreator.tsx](cci:7://file:///Users/neelmokaria/Documents/Coding%20Projects/Projects/Hack4Impact/for-all-ages/src/pages/Dashboard/AdminCreator.tsx:0:0-0:0)
- No existing Firestore data was modified (read-only operations)
- The change ensures participant privacy when sending bulk announcements
- Edge case handled: Empty admin email defaults to empty string in TO field
- Backward compatible: No breaking changes to existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Feature Improvements**
  * Admin bulk messaging now composes emails with the logged-in admin as the primary "To" address and other recipients placed in BCC, reducing exposure of recipient addresses.
  * Recipient addresses are gathered more reliably for mailto links to improve consistency when composing bulk emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->