### PR TITLE
profile load fix

### DIFF
--- a/src/pages/Profile/components/ProfilePicture/ProfilePicture.tsx
+++ b/src/pages/Profile/components/ProfilePicture/ProfilePicture.tsx
@@ -1,20 +1,26 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "../../Profile.module.css";
 
 const ProfilePicture = ({
   uid,
   size = 64,
+  version,
 }: {
   uid?: string;
   size?: number;
+  version?: number;
 }) => {
   const [imageError, setImageError] = useState(false);
+
+  useEffect(() => {
+    setImageError(false);
+  }, [uid, version]);
 
   const defaultSrc =
     "https://i.pinimg.com/474x/33/f8/26/33f8266681c946cd80de486c499fe992.jpg";
 
   const src = uid
-    ? `https://storage.googleapis.com/for-all-ages-cdn/profile-pictures/${uid}?t=${Date.now()}`
+    ? `https://storage.googleapis.com/for-all-ages-cdn/profile-pictures/${uid}${version !== undefined ? `?t=${version}` : ""}`
     : "";
 
   return (

--- a/src/pages/Profile/components/ProfilePictureEdit/ProfilePictureEdit.tsx
+++ b/src/pages/Profile/components/ProfilePictureEdit/ProfilePictureEdit.tsx
@@ -13,6 +13,7 @@ export default function ProfilePictureEdit({ uid }: ProfilePictureEditProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [removed, setRemoved] = useState(false);
+  const [version, setVersion] = useState<number | undefined>(undefined);
 
   const handleEditClick = () => {
     setMenuOpen((prev) => !prev);
@@ -49,7 +50,7 @@ export default function ProfilePictureEdit({ uid }: ProfilePictureEditProps) {
 
       setRemoved(false);
       setMenuOpen(false);
-      window.location.reload();
+      setVersion(Date.now());
     } catch (err) {
       console.error("Upload failed:", err);
     } finally {
@@ -89,8 +90,6 @@ export default function ProfilePictureEdit({ uid }: ProfilePictureEditProps) {
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
-
-      window.location.reload();
     } catch (err) {
       console.error("Remove failed:", err);
     } finally {
@@ -101,7 +100,7 @@ export default function ProfilePictureEdit({ uid }: ProfilePictureEditProps) {
   return (
     <div className={styles.container}>
       <div className={styles.pictureWrapper}>
-        <ProfilePicture uid={removed ? undefined : uid} size={190} />
+        <ProfilePicture uid={removed ? undefined : uid} size={190} version={version} />
 
         <button
           type="button"


### PR DESCRIPTION

# Pull Request

## Description
Added a version-based cache invalidation system so profile pictures update instantly after upload or removal without refreshing the whole page.

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues (put task name here from Notion)
(Bug Fix) Profile Picture Load Fix

## Pre-Submission Checklist

### Code Review Preparation
- [X] I have performed a self-review and reviewed the changed files
- [X] My code follows the project's style guidelines and passes linting
- [X] I have added comments in hard-to-understand areas and updated documentation

### Testing
- [ ] I have added relevant tests and they pass locally
- [X] I have tested the changes manually, including edge cases

### Code Quality & Security
- [X] I have formatted my code and removed debugging/unused code
- [X] No TypeScript errors or linting issues
- [X] No sensitive information committed (API keys, passwords, etc.)
- [X] User inputs are validated and sanitized

## Screenshots/Screen recording
https://github.com/user-attachments/assets/f4bf76a4-e9ee-4c54-b24d-a045c6f1f382



## Additional Notes
None.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile picture now updates instantly after upload or removal without requiring a page reload, providing immediate visual feedback and a faster, more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->