### PR TITLE
Add google maps autocomplete to address input with country/state drop…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@googlemaps/js-api-loader": "^2.0.2",
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.2",
+        "country-state-city": "^3.2.1",
         "firebase": "^12.2.1",
         "munkres-js": "^1.2.2",
         "react": "^19.1.1",
@@ -26,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
+        "@types/google.maps": "^3.64.0",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
@@ -1566,6 +1569,15 @@
       "version": "1.0.5",
       "license": "Apache-2.0"
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "license": "Apache-2.0",
@@ -2422,6 +2434,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.64.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.64.0.tgz",
+      "integrity": "sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -3001,6 +3019,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/country-state-city": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/country-state-city/-/country-state-city-3.2.1.tgz",
+      "integrity": "sha512-kxbanqMc6izjhc/EHkGPCTabSPZ2G6eG4/97akAYHJUN4stzzFEvQPZoF8oXDQ+10gM/O/yUmISCR1ZVxyb6EA==",
+      "license": "GPL-3.0"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4713,24 +4737,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@googlemaps/js-api-loader": "^2.0.2",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
+    "country-state-city": "^3.2.1",
     "firebase": "^12.2.1",
     "munkres-js": "^1.2.2",
     "react": "^19.1.1",
@@ -28,6 +30,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
+    "@types/google.maps": "^3.64.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",

--- a/src/pages/Registration/Question Types/AddressInput.tsx
+++ b/src/pages/Registration/Question Types/AddressInput.tsx
@@ -1,13 +1,10 @@
+import { useState, useEffect, useRef } from "react";
+import { Country, State } from "country-state-city";
+import { setOptions, importLibrary } from "@googlemaps/js-api-loader";
 import styles from "../Registration.module.css";
 
-const ADDRESS_FIELDS = [
-  { key: "line1", label: "Street Address" },
-  { key: "line2", label: "Street Address 2" },
-  { key: "city", label: "City" },
-  { key: "state", label: "State / Province" },
-  { key: "postalCode", label: "Postal / Zip Code" },
-  { key: "country", label: "Country" },
-] as const;
+// Guard: setOptions must only be called once per page load
+let mapsOptionsInitialized = false;
 
 export default function AddressInput({
   namePrefix,
@@ -16,39 +13,248 @@ export default function AddressInput({
   namePrefix: string;
   required: boolean;
 }) {
-  const streetFields = ADDRESS_FIELDS.filter(
-    (f) => f.key === "line1" || f.key === "line2",
-  );
+  const [line1, setLine1] = useState("");
+  const [line2, setLine2] = useState("");
+  const [city, setCity] = useState("");
+  const [stateVal, setStateVal] = useState("");
+  const [postalCode, setPostalCode] = useState("");
+  const [countryName, setCountryName] = useState("");
+  const [countryCode, setCountryCode] = useState("");
+  const [suggestions, setSuggestions] = useState<google.maps.places.AutocompleteSuggestion[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
-  const detailFields = ADDRESS_FIELDS.filter(
-    (f) => f.key !== "line1" && f.key !== "line2",
-  );
+  const allCountriesRef = useRef(Country.getAllCountries());
+  const placesLibRef = useRef<google.maps.PlacesLibrary | null>(null);
+  const sessionTokenRef = useRef<google.maps.places.AutocompleteSessionToken | null>(null);
+
+  const allCountries = allCountriesRef.current;
+  const states = countryCode ? State.getStatesOfCountry(countryCode) : [];
+
+  useEffect(() => {
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
+    if (!apiKey) return;
+
+    if (!mapsOptionsInitialized) {
+      setOptions({ key: apiKey });
+      mapsOptionsInitialized = true;
+    }
+
+    importLibrary("places").then((lib) => {
+      const pl = lib as google.maps.PlacesLibrary;
+      placesLibRef.current = pl;
+      sessionTokenRef.current = new pl.AutocompleteSessionToken();
+    });
+  }, []);
+
+  const handleCountryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const name = e.target.value;
+    const found = allCountries.find((c) => c.name === name);
+    setCountryName(name);
+    setCountryCode(found?.isoCode ?? "");
+    setStateVal("");
+  };
+
+  const handleLine1Change = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setLine1(value);
+
+    if (!value.trim() || !placesLibRef.current) {
+      setSuggestions([]);
+      return;
+    }
+
+    try {
+      const { AutocompleteSuggestion } = placesLibRef.current;
+      const result = await AutocompleteSuggestion.fetchAutocompleteSuggestions({
+        input: value,
+        sessionToken: sessionTokenRef.current ?? undefined,
+        includedPrimaryTypes: ["street_address"],
+      });
+      setSuggestions(result.suggestions);
+      setHighlightedIndex(-1);
+    } catch {
+      setSuggestions([]);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (suggestions.length === 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Enter" && highlightedIndex >= 0) {
+      e.preventDefault();
+      handleSelectSuggestion(suggestions[highlightedIndex]);
+    } else if (e.key === "Escape") {
+      setSuggestions([]);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  const handleSelectSuggestion = async (
+    suggestion: google.maps.places.AutocompleteSuggestion,
+  ) => {
+    setSuggestions([]);
+    const place = suggestion.placePrediction!.toPlace();
+    await place.fetchFields({ fields: ["addressComponents"] });
+
+    let streetNumber = "";
+    let route = "";
+
+    for (const component of place.addressComponents ?? []) {
+      const types = component.types;
+      if (types.includes("street_number")) streetNumber = component.longText ?? "";
+      if (types.includes("route")) route = component.shortText ?? "";
+      if (types.includes("locality")) setCity(component.longText ?? "");
+      if (types.includes("postal_code")) setPostalCode(component.longText ?? "");
+      if (types.includes("administrative_area_level_1"))
+        setStateVal(component.longText ?? "");
+      if (types.includes("country")) {
+        const name = component.longText ?? "";
+        const found = allCountriesRef.current.find((c) => c.name === name);
+        setCountryName(name);
+        setCountryCode(found?.isoCode ?? "");
+      }
+    }
+
+    setLine1(`${streetNumber} ${route}`.trim());
+    setHighlightedIndex(-1);
+
+    // Refresh session token after each completed selection
+    if (placesLibRef.current) {
+      sessionTokenRef.current =
+        new placesLibRef.current.AutocompleteSessionToken();
+    }
+  };
 
   return (
     <div>
-      {streetFields.map((f) => (
-        <div key={f.key} className={styles.fieldGroup}>
-          <span className={styles.fieldLabel}>{f.label}</span>
+      {/* Street Address */}
+      <div className={styles.fieldGroup}>
+        <span className={styles.fieldLabel}>Street Address</span>
+        <div style={{ position: "relative" }}>
           <input
             className={styles.fieldInput}
             type="text"
-            name={`${namePrefix}.${f.key}`}
-            required={f.key === "line1" ? required : false}
+            name={`${namePrefix}.line1`}
+            value={line1}
+            onChange={handleLine1Change}
+            onKeyDown={handleKeyDown}
+            onBlur={() => { setSuggestions([]); setHighlightedIndex(-1); }}
+            required={required}
+            autoComplete="off"
+            aria-autocomplete="list"
+            aria-expanded={suggestions.length > 0}
+          />
+          {suggestions.length > 0 && (
+            <ul className={styles.suggestionsList}>
+              {suggestions.map((s, i) => (
+                <li
+                  key={i}
+                  className={`${styles.suggestionItem}${i === highlightedIndex ? ` ${styles.suggestionItemHighlighted}` : ""}`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelectSuggestion(s);
+                  }}
+                  onMouseEnter={() => setHighlightedIndex(i)}
+                >
+                  {s.placePrediction?.text?.toString() ?? ""}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Street Address 2 */}
+      <div className={styles.fieldGroup}>
+        <span className={styles.fieldLabel}>Street Address 2</span>
+        <input
+          className={styles.fieldInput}
+          type="text"
+          name={`${namePrefix}.line2`}
+          value={line2}
+          onChange={(e) => setLine2(e.target.value)}
+        />
+      </div>
+
+      {/* City / State / Postal Code / Country */}
+      <div className={styles.addressSubRow}>
+        <div className={styles.fieldGroup}>
+          <span className={styles.fieldLabel}>City</span>
+          <input
+            className={styles.fieldInput}
+            type="text"
+            name={`${namePrefix}.city`}
+            value={city}
+            onChange={(e) => setCity(e.target.value)}
+            required={required}
           />
         </div>
-      ))}
-      <div className={styles.addressSubRow}>
-        {detailFields.map((f) => (
-          <div key={f.key} className={styles.fieldGroup}>
-            <span className={styles.fieldLabel}>{f.label}</span>
+
+        <div className={styles.fieldGroup}>
+          <span className={styles.fieldLabel}>State / Province</span>
+          {states.length > 0 ? (
+            <select
+              className={styles.fieldSelect}
+              name={`${namePrefix}.state`}
+              value={stateVal}
+              onChange={(e) => setStateVal(e.target.value)}
+              required={required}
+            >
+              <option value="">Select a state</option>
+              {states.map((s) => (
+                <option key={s.isoCode} value={s.name}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          ) : (
             <input
               className={styles.fieldInput}
               type="text"
-              name={`${namePrefix}.${f.key}`}
+              name={`${namePrefix}.state`}
+              value={stateVal}
+              onChange={(e) => setStateVal(e.target.value)}
               required={required}
             />
-          </div>
-        ))}
+          )}
+        </div>
+
+        <div className={styles.fieldGroup}>
+          <span className={styles.fieldLabel}>Postal / Zip Code</span>
+          <input
+            className={styles.fieldInput}
+            type="text"
+            name={`${namePrefix}.postalCode`}
+            value={postalCode}
+            onChange={(e) => setPostalCode(e.target.value)}
+            required={required}
+          />
+        </div>
+
+        <div className={styles.fieldGroup}>
+          <span className={styles.fieldLabel}>Country</span>
+          <select
+            className={styles.fieldSelect}
+            name={`${namePrefix}.country`}
+            value={countryName}
+            onChange={handleCountryChange}
+            required={required}
+          >
+            <option value="">Select a country</option>
+            {allCountries.map((c) => (
+              <option key={c.isoCode} value={c.name}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Registration/Registration.module.css
+++ b/src/pages/Registration/Registration.module.css
@@ -472,3 +472,38 @@
   color: #555;
   margin-bottom: 1.5rem;
 }
+
+.suggestionsList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: white;
+  border: 1.5px solid #ccc;
+  border-top: none;
+  border-radius: 0 0 6px 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.suggestionItem {
+  padding: 0.55rem 0.75rem;
+  font-size: 0.9rem;
+  color: #222;
+  cursor: pointer;
+}
+
+.suggestionItem:hover {
+  background: #f0f7ff;
+}
+
+.suggestionItem + .suggestionItem {
+  border-top: 1px solid #eee;
+}
+
+.suggestionItemHighlighted {
+  background: #f0f7ff;
+}


### PR DESCRIPTION
# Pull Request

## Description

Replaces the plain text inputs for **Country** and **State** fields in the registration address form with dynamic dropdown selects, and adds **Google Maps Address Autofill** to the street address field.

### Changes made:
- **Country dropdown**: Populated with a comprehensive list of all countries via the `country-state-city` npm package.
- **State dropdown**: Dynamically populated based on the selected country. Falls back to a free-text input for countries with no known states/provinces.
- **Google Maps Address Autofill**: Integrated the Google Places API (New) `AutocompleteSuggestion` headless API on the street address field. Selecting a suggestion auto-fills line1, city, state, postal code, and country.
- **Keyboard navigation**: Arrow keys (↑↓), Enter, and Escape work on the suggestions dropdown.
- **Manual entry**: All fields remain manually editable — dropdowns and autofill are additive, not restrictive.

### Files changed:
- `src/pages/Registration/Question Types/AddressInput.tsx` — Rewrote from uncontrolled to controlled component with full state management, country/state dropdowns, and Google Places autofill integration.
- `src/pages/Registration/Registration.module.css` — Added styles for the autofill suggestions dropdown (`.suggestionsList`, `.suggestionItem`, `.suggestionItemHighlighted`).
- `package.json` / `package-lock.json` — Added `country-state-city`, `@googlemaps/js-api-loader`, and `@types/google.maps` (dev).

### Backend compatibility:
- **No changes** to `RegistrationNew.tsx`, `Profile.tsx`, `AdminCreator.tsx`, or `types.ts`.
- The `name` attributes on all form inputs/selects are unchanged, so `parseAddress()` via `FormData` continues to work identically.
- Data written to Firestore retains the same `RawAddress` shape: `{ line1, line2, city, state, postalCode, country }` — all plain strings.
- Country and state are now stored as **full names** (e.g., `"United States"`, `"California"`) rather than free-form text, which is consistent with the existing `RawAddress` string type.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Pre-Submission Checklist

### Code Review Preparation
- [x] I have performed a self-review and reviewed the changed files
- [x] My code follows the project's style guidelines and passes linting
- [x] I have added comments in hard-to-understand areas and updated documentation

### Testing
- [ ] I have added relevant tests and they pass locally
- [x] I have tested the changes manually, including edge cases

### Code Quality & Security
- [x] I have formatted my code and removed debugging/unused code
- [x] No TypeScript errors or linting issues
- [x] No sensitive information committed (API keys, passwords, etc.)
- [x] User inputs are validated and sanitized

## Screenshots/Screen recording
<img width="1694" height="1124" alt="image" src="https://github.com/user-attachments/assets/66f15001-b049-4294-89d7-6a740ab698a8" />
<img width="1830" height="1068" alt="image" src="https://github.com/user-attachments/assets/4bd4143a-16b1-49a2-8a2e-494fc074ca00" />



## Additional Notes

- The Google Maps API key is stored in `.env.local` (gitignored) as `VITE_GOOGLE_MAPS_API_KEY`.  We need to add this key to their local `.env.local` to enable autofill. If the key is missing, the address field still works as a normal manual text input — autofill is gracefully disabled.
- The "Places API (New)" must be enabled in the Google Cloud Console for the API key to work (this is separate from the legacy "Places API").
- Existing Firestore documents with old free-form country/state values (e.g., `"USA"`, `"CA"`) are unaffected. However, if those users edit their profile, they will need to re-select from the dropdowns since the old values may not match any dropdown option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Address input now includes Google Places Autocomplete with street address suggestions.
  * Automatic population of address fields (street, city, state, postal code, country) from selected suggestions.
  * Keyboard navigation support (arrow keys, enter, escape) for address suggestions.
  * Dynamic country/state selection with intelligent dropdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->