### PR TITLE
fixed form submission bug for adult user_type

### DIFF
--- a/src/pages/Registration/RegistrationNew.tsx
+++ b/src/pages/Registration/RegistrationNew.tsx
@@ -276,11 +276,8 @@ const RegistrationNew = () => {
   };
 
   const isUserTypeQuestion = (question: Question): boolean => {
-    if (question.lockedKey === "user type") {
-      return true;
-    }
-    const title = question.title.toLowerCase();
-    return title.includes("student") && title.includes("adult");
+    // Use strict matching based on lockedKey to avoid false positives
+    return question.lockedKey === "user type";
   };
 
   const isBasicInfoQuestion = (question: Question): boolean => {
@@ -298,7 +295,7 @@ const RegistrationNew = () => {
   };
 
   const normalizeUserType = (value?: string): "student" | "adult" => {
-    const normalized = value?.trim().toLowerCase();
+    const normalized = value?.trim().toLowerCase() ?? "";
     return normalized === "adult" ? "adult" : "student";
   };
 
@@ -351,7 +348,11 @@ const RegistrationNew = () => {
       } else if (isEmailQuestion(question)) {
         values[BASIC_FIELD_KEYS.email] = (formData.get(fieldName) as string) || "";
       } else if (isUserTypeQuestion(question)) {
-        values[BASIC_FIELD_KEYS.userType] = (formData.get(fieldName) as string) || "";
+        // Only assign user_type if a non-empty value is found (prevents overwrite by empty matches)
+        const userTypeValue = (formData.get(fieldName) as string)?.trim();
+        if (userTypeValue) {
+          values[BASIC_FIELD_KEYS.userType] = userTypeValue;
+        }
       }
     });
 


### PR DESCRIPTION
Previously, selecting "Adult" in the form didn't work, as participants were being assigned the "student" user_type in Firebase instead of "adult." The registration form now uses a strict comparison with lockedKey instead of a fuzzy title-based check. It also normalizes "adult" to adult and everything else to student. It also only assigns a user_type if a non-empty value is found, preventing incorrect overwrites. 