### PR TITLE
Create a “show password” box

### DIFF
--- a/src/pages/Login/Login-Signup.tsx
+++ b/src/pages/Login/Login-Signup.tsx
@@ -52,6 +52,9 @@ function LoginSignup() {
   const [resendLoading, setResendLoading] = useState(false);
   const [forgotPasswordLoading, setForgotPasswordLoading] = useState(false);
   const {isAdmin} = useAuth()
+  const [showLoginPassword, setShowLoginPassword] = useState(false);
+  const [showSignupPassword, setShowSignupPassword] = useState(false);
+  const [showSignupConfirmPassword, setShowSignupConfirmPassword] = useState(false);
 
   //verification panel if a user is signed in but not yet verified
   const needsVerification = useMemo(
@@ -79,6 +82,9 @@ function LoginSignup() {
 
   useEffect(() => {
     setError(null);
+    setShowLoginPassword(false);
+    setShowSignupPassword(false);
+    setShowSignupConfirmPassword(false);
   }, [tab]);
 
   const handleLoginChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -264,7 +270,7 @@ function LoginSignup() {
                     Password
                   </label>
                   <input
-                    type="password"
+                    type={showLoginPassword ? "text" : "password"}
                     id="loginPassword"
                     name="password"
                     className={styles.input}
@@ -273,6 +279,17 @@ function LoginSignup() {
                     autoComplete="current-password"
                     required
                   />
+                  <div className={styles.showPasswordRow}>
+                    <input
+                      type="checkbox"
+                      id="showLoginPassword"
+                      checked={showLoginPassword}
+                      onChange={(e) => setShowLoginPassword(e.target.checked)}
+                    />
+                    <label htmlFor="showLoginPassword" className={styles.showPasswordLabel}>
+                      Show password
+                    </label>
+                  </div>
                 </div>
 
                 <button
@@ -345,7 +362,7 @@ function LoginSignup() {
                     Password
                   </label>
                   <input
-                    type="password"
+                    type={showSignupPassword ? "text" : "password"}
                     id="signupPassword"
                     name="password"
                     className={styles.input}
@@ -354,6 +371,17 @@ function LoginSignup() {
                     autoComplete="new-password"
                     required
                   />
+                  <div className={styles.showPasswordRow}>
+                    <input
+                      type="checkbox"
+                      id="showSignupPassword"
+                      checked={showSignupPassword}
+                      onChange={(e) => setShowSignupPassword(e.target.checked)}
+                    />
+                    <label htmlFor="showSignupPassword" className={styles.showPasswordLabel}>
+                      Show password
+                    </label>
+                  </div>
                 </div>
 
                 <div className={styles.inputGroup}>
@@ -361,7 +389,7 @@ function LoginSignup() {
                     Confirm Password
                   </label>
                   <input
-                    type="password"
+                    type={showSignupConfirmPassword ? "text" : "password"}
                     id="confirmPassword"
                     name="confirmPassword"
                     className={styles.input}
@@ -370,6 +398,17 @@ function LoginSignup() {
                     autoComplete="new-password"
                     required
                   />
+                  <div className={styles.showPasswordRow}>
+                    <input
+                      type="checkbox"
+                      id="showSignupConfirmPassword"
+                      checked={showSignupConfirmPassword}
+                      onChange={(e) => setShowSignupConfirmPassword(e.target.checked)}
+                    />
+                    <label htmlFor="showSignupConfirmPassword" className={styles.showPasswordLabel}>
+                      Show confirm password
+                    </label>
+                  </div>
                   {signupForm.password &&
                     signupForm.confirmPassword &&
                     signupForm.password !== signupForm.confirmPassword && (

--- a/src/pages/Login/Login.module.css
+++ b/src/pages/Login/Login.module.css
@@ -117,6 +117,48 @@
     background: #D9EEF9;
 }
 
+.showPasswordRow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.35rem;
+}
+
+.showPasswordRow input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 1.15em;
+    height: 1.15em;
+    margin: 0;
+    flex-shrink: 0;
+    border: 2px solid #127BBE;
+    border-radius: 3px;
+    background: #fff;
+    cursor: pointer;
+    vertical-align: middle;
+}
+
+.showPasswordRow input[type="checkbox"]:checked {
+    background-color: #127BBE;
+    border-color: #127BBE;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
+    background-size: 0.75em;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.showPasswordRow input[type="checkbox"]:focus-visible {
+    outline: 2px solid #127BBE;
+    outline-offset: 2px;
+}
+
+.showPasswordLabel {
+    font-family: 'Merriweather', serif;
+    font-size: 0.85rem;
+    color: #555;
+    cursor: pointer;
+}
+
 .submitButton {
     padding: 0.8rem;
     background: #127BBE;

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -252,6 +252,48 @@
   height: 40px;
 }
 
+.showPasswordRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.showPasswordRow input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1.15em;
+  height: 1.15em;
+  margin: 0;
+  flex-shrink: 0;
+  border: 2px solid #1d4e89;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.showPasswordRow input[type="checkbox"]:checked {
+  background-color: #1d4e89;
+  border-color: #1d4e89;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
+  background-size: 0.75em;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.showPasswordRow input[type="checkbox"]:focus-visible {
+  outline: 2px solid #1d4e89;
+  outline-offset: 2px;
+}
+
+.showPasswordLabel {
+  font-size: 13px;
+  color: #555;
+  cursor: pointer;
+  user-select: none;
+}
+
 .textarea {
   border: 1px solid #c3d0ea;
   height: 100px;

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -98,6 +98,10 @@ const Profile = () => {
   const [passwordSuccess, setPasswordSuccess] = useState<string | null>(null);
   const [isUpdatingPassword, setIsUpdatingPassword] = useState(false);
 
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmNewPassword, setShowConfirmNewPassword] = useState(false);
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (fbUser) => {
       if (!fbUser) {
@@ -437,6 +441,9 @@ const Profile = () => {
       setPasswordCurrent("");
       setNewPassword("");
       setConfirmNewPassword("");
+      setShowCurrentPassword(false);
+      setShowNewPassword(false);
+      setShowConfirmNewPassword(false);
     } catch (err: unknown) {
       console.error("Error updating password:", err);
 
@@ -655,7 +662,7 @@ const Profile = () => {
                   <span className={styles.boxLabel}>Current Password</span>
                 </div>
                 <input
-                  type="password"
+                  type={showCurrentPassword ? "text" : "password"}
                   className={styles.input}
                   value={passwordCurrent}
                   onChange={(e) => {
@@ -663,7 +670,19 @@ const Profile = () => {
                     if (passwordError) setPasswordError(null);
                     if (passwordSuccess) setPasswordSuccess(null);
                   }}
+                  autoComplete="current-password"
                 />
+                <div className={styles.showPasswordRow}>
+                  <input
+                    type="checkbox"
+                    id="profileShowCurrentPassword"
+                    checked={showCurrentPassword}
+                    onChange={(e) => setShowCurrentPassword(e.target.checked)}
+                  />
+                  <label htmlFor="profileShowCurrentPassword" className={styles.showPasswordLabel}>
+                    Show password
+                  </label>
+                </div>
               </div>
             </div>
 
@@ -673,14 +692,26 @@ const Profile = () => {
                   <span className={styles.boxLabel}>New Password</span>
                 </div>
                 <input
-                  type="password"
+                  type={showNewPassword ? "text" : "password"}
                   className={styles.input}
                   value={newPassword}
                   onChange={(e) => {
                     setNewPassword(e.target.value);
                     if (passwordSuccess) setPasswordSuccess(null);
                   }}
+                  autoComplete="new-password"
                 />
+                <div className={styles.showPasswordRow}>
+                  <input
+                    type="checkbox"
+                    id="profileShowNewPassword"
+                    checked={showNewPassword}
+                    onChange={(e) => setShowNewPassword(e.target.checked)}
+                  />
+                  <label htmlFor="profileShowNewPassword" className={styles.showPasswordLabel}>
+                    Show password
+                  </label>
+                </div>
               </div>
             </div>
 
@@ -690,14 +721,26 @@ const Profile = () => {
                   <span className={styles.boxLabel}>Confirm New Password</span>
                 </div>
                 <input
-                  type="password"
+                  type={showConfirmNewPassword ? "text" : "password"}
                   className={styles.input}
                   value={confirmNewPassword}
                   onChange={(e) => {
                     setConfirmNewPassword(e.target.value);
                     if (passwordSuccess) setPasswordSuccess(null);
                   }}
+                  autoComplete="new-password"
                 />
+                <div className={styles.showPasswordRow}>
+                  <input
+                    type="checkbox"
+                    id="profileShowConfirmNewPassword"
+                    checked={showConfirmNewPassword}
+                    onChange={(e) => setShowConfirmNewPassword(e.target.checked)}
+                  />
+                  <label htmlFor="profileShowConfirmNewPassword" className={styles.showPasswordLabel}>
+                    Show password
+                  </label>
+                </div>
               </div>
             </div>
 

--- a/src/pages/Registration/Registration.module.css
+++ b/src/pages/Registration/Registration.module.css
@@ -284,10 +284,31 @@
 }
 
 .checkboxRow input[type="checkbox"] {
-  width: 1.1em;
-  height: 1.1em;
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1.15em;
+  height: 1.15em;
+  margin: 0;
+  flex-shrink: 0;
+  border: 2px solid #127BBE;
+  border-radius: 3px;
+  background: #fff;
   cursor: pointer;
-  accent-color: #127BBE;
+  vertical-align: middle;
+}
+
+.checkboxRow input[type="checkbox"]:checked {
+  background-color: #127BBE;
+  border-color: #127BBE;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
+  background-size: 0.75em;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.checkboxRow input[type="checkbox"]:focus-visible {
+  outline: 2px solid #127BBE;
+  outline-offset: 2px;
 }
 
 .returningRow {


### PR DESCRIPTION
# Pull Request

## Description
Adds “Show password” checkboxes on login, sign-up (password and confirm), and profile change-password fields


## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues (put task name here from Notion)
Create a “show password” box


## Pre-Submission Checklist

### Code Review Preparation
- [x] I have performed a self-review and reviewed the changed files
- [x] My code follows the project's style guidelines and passes linting
- [x] I have added comments in hard-to-understand areas and updated documentation

### Testing
- [x] I have added relevant tests and they pass locally
- [x] I have tested the changes manually, including edge cases

### Code Quality & Security
- [x] I have formatted my code and removed debugging/unused code
- [x] No TypeScript errors or linting issues
- [x] No sensitive information committed (API keys, passwords, etc.)
- [x] User inputs are validated and sanitized

## Screenshots/Screen recording
<img width="2460" height="1262" alt="image" src="https://github.com/user-attachments/assets/20a01120-1d67-43fa-b2b9-df30fbbe3b9d" />
<img width="1289" height="784" alt="Screenshot 2026-04-19 at 8 04 58 PM" src="https://github.com/user-attachments/assets/c0ee8f0a-2235-44c2-8da7-b9c810586a8d" />


## Additional Notes