### PR TITLE
profile page, user dash date range, admin match lock

### DIFF
--- a/src/pages/Dashboard/Dashboard.module.css
+++ b/src/pages/Dashboard/Dashboard.module.css
@@ -27,11 +27,26 @@
     flex: 1;
 }
 
+.sectionHeader {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
 .sectionHeading {
     margin: 0;
     font-size: clamp(1.75rem, 2vw, 2.25rem);
     font-weight: 700;
     color: #ffffff;
+    text-align: center;
+}
+
+.sectionSubheading {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: clamp(1rem, 1.4vw, 1.125rem);
+    font-weight: 500;
     text-align: center;
 }
 

--- a/src/pages/Dashboard/UserDashboard.tsx
+++ b/src/pages/Dashboard/UserDashboard.tsx
@@ -4,30 +4,106 @@ import userStyles from "./UserDashboard.module.css"
 import WeekSelector from "./components/WeekSelector/WeekSelector";
 import LogCallForm from "./components/LogCallForm/LogCallForm";
 import { useAuth } from "../../auth/AuthProvider";
-import { getCurrentWeek } from "../../utils/programWeek";
+import {
+  getCurrentWeek,
+  getWeekDateLabel,
+  getWeekDateLabelLong,
+} from "../../utils/programWeek";
+import { getLogsByParticipant } from "../../services/logs";
 
 export default function UserDashboard() {
-  const { programState } = useAuth();
+  const { programState, user } = useAuth();
   const numWeeks = Math.max(1, programState?.numWeeks ?? 20);
+  const [selectedWeek, setSelectedWeek] = useState(0);
+  const [submittedWeeks, setSubmittedWeeks] = useState<Set<number>>(
+    () => new Set(),
+  );
+  const hasInitalized = useRef(false);
+  const currentWeek = getCurrentWeek(programState?.startDate, numWeeks);
+  const currentWeekIndex = currentWeek - 1;
   const weekLabels = useMemo(
     () => Array.from({ length: numWeeks }, (_, i) => `Week ${i + 1}`),
     [numWeeks]
   );
-  const [selectedWeek, setSelectedWeek] = useState(0);
-  const hasInitalized = useRef(false);
+  const weekDateLabels = useMemo(
+    () =>
+      Array.from({ length: numWeeks }, (_, i) =>
+        getWeekDateLabel(programState?.startDate, i + 1),
+      ),
+    [numWeeks, programState?.startDate],
+  );
+  const selectedWeekDateLabel = getWeekDateLabelLong(
+    programState?.startDate,
+    selectedWeek + 1,
+  );
+  const weekStatuses = useMemo(
+    () =>
+      Array.from({ length: numWeeks }, (_, i) => {
+        const week = i + 1;
+        const hasSubmitted = submittedWeeks.has(week);
+        if (week < currentWeek) return hasSubmitted ? "submitted" : "missing";
+        if (week === currentWeek) return "current";
+        return "future";
+      }) as (
+        | "submitted"
+        | "missing"
+        | "future"
+        | "current"
+      )[],
+    [currentWeek, numWeeks, submittedWeeks],
+  );
 
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadSubmittedWeeks() {
+      if (!user?.uid) {
+        setSubmittedWeeks(new Set());
+        return;
+      }
+
+      try {
+        const logs = await getLogsByParticipant(user.uid);
+        if (!isMounted) return;
+        setSubmittedWeeks(new Set(logs.map((log) => log.week)));
+      } catch (error) {
+        console.error("Failed to load submitted weeks", error);
+        if (isMounted) {
+          setSubmittedWeeks(new Set());
+        }
+      }
+    }
+
+    loadSubmittedWeeks();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [user?.uid]);
 
   useEffect(() => {
     if (programState && !hasInitalized.current) {
-      const week = getCurrentWeek(programState.startDate, programState.numWeeks ?? 20)
-      setSelectedWeek(week - 1);
+      setSelectedWeek(currentWeekIndex);
       hasInitalized.current = true;
     }
-  }, [programState])
+  }, [currentWeekIndex, programState])
   
   useEffect(() => {
-    setSelectedWeek((prev) => Math.min(prev, numWeeks - 1));
-  }, [numWeeks]);
+    setSelectedWeek((prev) => Math.min(prev, numWeeks - 1, currentWeekIndex));
+  }, [currentWeekIndex, numWeeks]);
+
+  const handleSelectWeek = (index: number) => {
+    if (index > currentWeekIndex) return;
+    setSelectedWeek(index);
+  };
+
+  const handleLogSuccess = () => {
+    setSubmittedWeeks((prev) => {
+      const next = new Set(prev);
+      next.add(selectedWeek + 1);
+      return next;
+    });
+  };
 
   return (
     <div className={userStyles.page}>
@@ -35,14 +111,25 @@ export default function UserDashboard() {
         <section className={styles.selectorSection}>
           <WeekSelector
             weeks={weekLabels}
+            subLabels={weekDateLabels}
             selectedWeekIndex={selectedWeek}
-            onSelect={setSelectedWeek}
+            onSelect={handleSelectWeek}
+            statuses={weekStatuses}
+            maxSelectableIndex={currentWeekIndex}
+            showCurrentIndicator
           />
         </section>
 
         <section className={styles.contentSection}>
-          <h2 className={styles.sectionHeading}>Week {selectedWeek + 1}</h2>
-          <LogCallForm weekNumber={selectedWeek + 1} />
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionHeading}>Week {selectedWeek + 1}</h2>
+            {selectedWeekDateLabel && (
+              <p className={styles.sectionSubheading}>
+                {selectedWeekDateLabel}
+              </p>
+            )}
+          </div>
+          <LogCallForm weekNumber={selectedWeek + 1} onSuccess={handleLogSuccess} />
         </section>
       </div>
     </div>

--- a/src/pages/Dashboard/components/WeekSelector/WeekSelector.tsx
+++ b/src/pages/Dashboard/components/WeekSelector/WeekSelector.tsx
@@ -1,12 +1,22 @@
 import styles from './WeekSelectorGlassy.module.css'
 
+type WeekStatus =
+    | 'completed'
+    | 'missed'
+    | 'future'
+    | 'current'
+    | 'submitted'
+    | 'missing'
+
 interface WeekSelectorProps {
     weeks: string[]
     subLabels?: string[]
     selectedWeekIndex: number
     onSelect: (index: number) => void
     className?: string
-    statuses?: ('completed' | 'missed' | 'future' | 'current')[]
+    statuses?: WeekStatus[]
+    maxSelectableIndex?: number
+    showCurrentIndicator?: boolean
 }
 
 export default function WeekSelector ({
@@ -15,7 +25,9 @@ export default function WeekSelector ({
     selectedWeekIndex,
     onSelect,
     className,
-    statuses = []
+    statuses = [],
+    maxSelectableIndex,
+    showCurrentIndicator = false
 }: WeekSelectorProps) {
     const handleArrowClick = (direction: number) => {
         const currentPage = Math.floor(selectedWeekIndex / weekRange);
@@ -23,7 +35,11 @@ export default function WeekSelector ({
 
         const newIndex = direction > 0 ? nextPage * weekRange : Math.min((nextPage + 1) * weekRange - 1, weeks.length - 1);
 
-        if (newIndex < 0 || newIndex >= weeks.length) {
+        if (
+            newIndex < 0 ||
+            newIndex >= weeks.length ||
+            (typeof maxSelectableIndex === 'number' && newIndex > maxSelectableIndex)
+        ) {
             return
         }
         onSelect(newIndex)
@@ -50,8 +66,14 @@ export default function WeekSelector ({
                     const actualIndex = startIndex + index;
                     const isActive = actualIndex === selectedWeekIndex
                     const status = statuses[actualIndex] || 'future';
-                    const showCheckmark = status === 'completed' || status === 'current'
+                    const showCheckmark =
+                        status === 'completed' ||
+                        status === 'submitted'
                     const subLabel = subLabels?.[actualIndex]
+                    const isDisabled =
+                        typeof maxSelectableIndex === 'number' &&
+                        actualIndex > maxSelectableIndex
+                    const isCurrent = status === 'current'
 
                     return (
                         <button
@@ -60,12 +82,16 @@ export default function WeekSelector ({
                             role="tab"
                             aria-selected={isActive}
                             className={`${styles.weekButton} ${isActive ? styles.activeWeek : ''} ${styles[status]}`.trim()}
+                            disabled={isDisabled}
                             onClick={() => onSelect(actualIndex)}
                         >
                             {subLabel ? (
                                 <span className={styles.weekButtonInner}>
                                     <span className={styles.weekButtonTop}>
                                         <span className={styles.weekLabel}>{week}</span>
+                                        {showCurrentIndicator && isCurrent && (
+                                            <span className={styles.currentIndicator}>Current</span>
+                                        )}
                                         {showCheckmark && (
                                             <span className={styles.checkmark} aria-hidden="true">✓</span>
                                         )}
@@ -75,6 +101,9 @@ export default function WeekSelector ({
                             ) : (
                                 <>
                                     <span className={styles.weekLabel}>{week}</span>
+                                    {showCurrentIndicator && isCurrent && (
+                                        <span className={styles.currentIndicator}>Current</span>
+                                    )}
                                     {showCheckmark && (
                                         <span className={styles.checkmark} aria-hidden="true">✓</span>
                                     )}
@@ -88,7 +117,11 @@ export default function WeekSelector ({
                 type="button"
                 className={styles.arrowButton}
                 onClick={() => handleArrowClick(5)}
-                disabled={startIndex + weekRange >= weeks.length}
+                disabled={
+                    startIndex + weekRange >= weeks.length ||
+                    (typeof maxSelectableIndex === 'number' &&
+                        startIndex + weekRange > maxSelectableIndex)
+                }
                 aria-label="Next 5 weeks"
             >
                 &#8250;

--- a/src/pages/Dashboard/components/WeekSelector/WeekSelectorGlassy.module.css
+++ b/src/pages/Dashboard/components/WeekSelector/WeekSelectorGlassy.module.css
@@ -64,10 +64,44 @@
     color: #1a3a5c;
 }
 
+.submitted,
+.completed {
+    background: #e6f7e3;
+    border-color: #8bcf83;
+    color: #247c2a;
+}
+
+.missing,
+.missed {
+    background: #fde9e7;
+    border-color: #e7a09b;
+    color: #a53a34;
+}
+
+.current {
+    background: #ffffff;
+    border-color: #0E6BAE;
+    color: #2B476C;
+}
+
+.weekButton:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    background: #f3f6fa;
+    border-color: #b8c6d8;
+    color: #7b8796;
+}
+
+.weekButton:disabled:hover {
+    background: #f3f6fa;
+    color: #7b8796;
+}
+
 .activeWeek {
     background: #0E4C82;
     color: #ffffff;
     border-color: #0E4C82;
+    box-shadow: 0 0 0 3px rgba(14, 76, 130, 0.22);
 }
 
 .activeWeek:hover {
@@ -75,7 +109,8 @@
     color: #ffffff;
 }
 
-.completed .checkmark {
+.completed .checkmark,
+.submitted .checkmark {
     color: #0E6BAE;
 }
 
@@ -91,6 +126,21 @@
     font-size: 0.8rem;
     font-weight: 700;
     line-height: 1;
+}
+
+.currentIndicator {
+    border-radius: 999px;
+    padding: 3px 7px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    line-height: 1;
+    background: rgba(14, 107, 174, 0.14);
+    color: #0E4C82;
+}
+
+.activeWeek .currentIndicator {
+    background: rgba(255, 255, 255, 0.22);
+    color: #ffffff;
 }
 
 .arrowButton {

--- a/src/pages/PreProgram/PreProgram.module.css
+++ b/src/pages/PreProgram/PreProgram.module.css
@@ -466,7 +466,8 @@
   font-weight: 600;
   text-align: center;
   box-sizing: border-box;
-  width: 50%;
+  min-width: 104px;
+  width: 64%;
 }
 
 .pending {
@@ -489,7 +490,8 @@
   font-weight: 600;
   text-align: center;
   box-sizing: border-box;
-  width: 50%;
+  min-width: 104px;
+  width: 64%;
   display: inline-block;
 }
 

--- a/src/pages/PreProgram/PreProgram.tsx
+++ b/src/pages/PreProgram/PreProgram.tsx
@@ -24,6 +24,7 @@ import {
   finalizeMatches,
   startProgram,
   subscribeToProgramState,
+  unfinalizeMatches,
   type ProgramState,
 } from "../../services/programState";
 import type {
@@ -59,7 +60,7 @@ const PreProgram = () => {
   const [startingProgram, setStartingProgram] = useState(false);
   const [finalizing, setFinalizing] = useState(false);
   const [confirmAction, setConfirmAction] = useState<
-    "start" | "finalize" | "endProgram" | null
+    "start" | "finalize" | "unfinalize" | "endProgram" | null
   >(null);
 
   // End Program state
@@ -488,6 +489,20 @@ const PreProgram = () => {
     }
   };
 
+  const handleUnfinalizeMatches = async () => {
+    try {
+      setProgramStateError(null);
+      setFinalizing(true);
+      await unfinalizeMatches();
+    } catch (err) {
+      console.error("Failed to unlock matches", err);
+      setProgramStateError("Failed to unlock matches. Please try again.");
+    } finally {
+      setFinalizing(false);
+      setConfirmAction(null);
+    }
+  };
+
   // ── Export Data ──────────────────────────────────────────────────────────────
 
   /**
@@ -757,13 +772,17 @@ const PreProgram = () => {
                 : "Start Program"}
           </button>
           <button
-            onClick={() => setConfirmAction("finalize")}
+            onClick={() =>
+              setConfirmAction(matchesFinalized ? "unfinalize" : "finalize")
+            }
             className={styles.adminBtn}
-            disabled={programStateLoading || finalizing || matchesFinalized}
+            disabled={programStateLoading || finalizing}
           >
             <LockOutlinedIcon className={styles.icon} />
             {matchesFinalized
-              ? "Matches Locked"
+              ? finalizing
+                ? "Unlocking..."
+                : "Matches Locked"
               : finalizing
                 ? "Locking..."
                 : "Lock In All Matches"}
@@ -779,15 +798,20 @@ const PreProgram = () => {
           <button
             onClick={handleMatch}
             className={styles.rematchBtn}
-            disabled={matching}
+            disabled={matching || matchesFinalized}
           >
             <AutorenewIcon className={styles.icon} />
-            {matching ? "Creating..." : "Create Matches"}
+            {matchesFinalized
+              ? "Matches Locked"
+              : matching
+                ? "Creating..."
+                : "Create Matches"}
           </button>
 
           <button
             className={styles.adminBtn}
             onClick={() => navigate("/admin/rematching")}
+            disabled={matchesFinalized}
           >
             Manual Rematch
           </button>
@@ -814,18 +838,24 @@ const PreProgram = () => {
       {confirmAction && (
         <div className={styles.confirmOverlay}>
           <div className={styles.confirmCard}>
-            {/* ── Start / Finalize dialogs (unchanged) ── */}
-            {(confirmAction === "start" || confirmAction === "finalize") && (
+            {/* ── Start / Finalize / Unlock dialogs ── */}
+            {(confirmAction === "start" ||
+              confirmAction === "finalize" ||
+              confirmAction === "unfinalize") && (
               <>
                 <h3 className={styles.confirmTitle}>
                   {confirmAction === "start"
                     ? "Starting the Program"
-                    : "Finalizing..."}
+                    : confirmAction === "finalize"
+                      ? "Finalizing..."
+                      : "Unlock Matches"}
                 </h3>
                 <p className={styles.confirmText}>
                   {confirmAction === "start"
                     ? "Are you sure you want to start the program?"
-                    : "Are you sure you want to lock all matches?"}
+                    : confirmAction === "finalize"
+                      ? "Are you sure you want to lock all matches?"
+                      : "Are you sure you want to unlock all matches? Participants will no longer be able to view finalized match details until matches are locked again."}
                 </p>
                 <div className={styles.confirmActions}>
                   <button
@@ -840,7 +870,9 @@ const PreProgram = () => {
                     onClick={
                       confirmAction === "start"
                         ? handleStartProgram
-                        : handleFinalizeMatches
+                        : confirmAction === "finalize"
+                          ? handleFinalizeMatches
+                          : handleUnfinalizeMatches
                     }
                     disabled={startingProgram || finalizing}
                   >
@@ -1047,6 +1079,7 @@ const PreProgram = () => {
                     ) : (
                       <select
                         value={m.status}
+                        disabled={matchesFinalized}
                         onChange={(e) =>
                           handleStatusChange(
                             m.matchId,

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -308,6 +308,78 @@
   resize: none;
 }
 
+.matchableResponses {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.matchableResponseCard {
+  background-color: #e5edf7;
+  border: 1px solid #c3d0ea;
+  border-radius: 10px;
+  padding: 14px;
+  box-sizing: border-box;
+}
+
+.matchableResponseHeader {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+
+.matchableQuestion {
+  margin: 0;
+  color: #1d4e89;
+  font-size: 15px;
+  line-height: 1.35;
+  font-weight: 700;
+  text-align: left;
+}
+
+.matchableTextResponse {
+  width: 100%;
+  min-height: 92px;
+  box-sizing: border-box;
+  border: 1px solid #c3d0ea;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1d4e89;
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1.45;
+  padding: 10px 12px;
+  resize: vertical;
+}
+
+.sliderResponse {
+  display: flex;
+  align-items: center;
+}
+
+.sliderValue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #1d4e89;
+  color: #ffffff;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.emptyMatchableResponses {
+  background-color: #e5edf7;
+  border: 1px solid #c3d0ea;
+  border-radius: 10px;
+  color: #1d4e89;
+  font-size: 15px;
+  font-weight: 500;
+  padding: 14px;
+}
+
 .error {
   color: #d9534f;
   font-size: 0.85rem;
@@ -358,6 +430,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 96px 16px 32px;
+  box-sizing: border-box;
   z-index: 999;
 }
 
@@ -367,7 +441,11 @@
   padding: 20px 24px;
   max-width: 420px;
   width: 90%;
+  max-height: min(82vh, 720px);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .modalHeader {
@@ -399,6 +477,11 @@
   font-size: 14px;
   color: #1d1d1d;
   line-height: 1.4;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
 }
 
 /* ------------------ Responsive styles ------------------ */

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,6 +1,6 @@
 import styles from "./Profile.module.css";
 import { useState, useEffect } from "react";
-import { dateRegex } from "../../regex";
+// import { dateRegex } from "../../regex";
 import { formatPhone, stripPhone, isValidPhone } from "../../utils/phone";
 import EditIcon from "@mui/icons-material/Edit";
 import {
@@ -14,48 +14,58 @@ import { auth, db } from "../../firebase";
 import { doc, getDoc, updateDoc } from "firebase/firestore";
 import { useNavigate } from "react-router-dom";
 import { getMatchesByParticipant, getPartnerId } from "../../services/matches";
-import type { ErrorState, ParticipantDoc, UserProfile } from "../../types";
+import type {
+  ErrorState,
+  Form,
+  FormResponse,
+  ParticipantDoc,
+  Question,
+  Questions,
+  UserProfile,
+} from "../../types";
 import MatchInterestsModal from "./components/MatchInterestsModal/MatchInterestsModal";
 import ProfilePictureEdit from "./components/ProfilePictureEdit/ProfilePictureEdit";
 import { useAuth } from "../../auth/AuthProvider";
 
-const toDisplayBirthday = (raw: string | undefined | null): string => {
-  if (!raw) return "";
-  if (/^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(raw)) {
-    return raw;
-  }
-
-  const iso = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (iso) {
-    const [, yyyy, mm, dd] = iso;
-    return `${mm}/${dd}/${yyyy}`;
-  }
-
-  const dashed = raw.match(/^(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])-(\d{4})$/);
-  if (dashed) {
-    const [, mm, dd, yyyy] = dashed;
-    return `${mm}/${dd}/${yyyy}`;
-  }
-
-  return raw;
-};
-
-const toStorageBirthday = (raw: string | undefined | null): string => {
-  if (!raw) return "";
-  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
-    return raw;
-  }
-
-  // normalize birthday to MM/DD/YYYY for profile display/edit
-  const display = toDisplayBirthday(raw);
-  const m = display.match(/^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/(\d{4})$/);
-  if (m) {
-    const [, mm, dd, yyyy] = m;
-    return `${yyyy}-${mm}-${dd}`;
-  }
-
-  return raw;
-};
+// Birthday display is disabled for now because it is not part of the
+// current registration form. Keep this formatter here for when birthday
+// collection is reintroduced.
+// const toDisplayBirthday = (raw: string | undefined | null): string => {
+//   if (!raw) return "";
+//   if (/^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/.test(raw)) {
+//     return raw;
+//   }
+//
+//   const iso = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+//   if (iso) {
+//     const [, yyyy, mm, dd] = iso;
+//     return `${mm}/${dd}/${yyyy}`;
+//   }
+//
+//   const dashed = raw.match(/^(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])-(\d{4})$/);
+//   if (dashed) {
+//     const [, mm, dd, yyyy] = dashed;
+//     return `${mm}/${dd}/${yyyy}`;
+//   }
+//
+//   return raw;
+// };
+//
+// const toStorageBirthday = (raw: string | undefined | null): string => {
+//   if (!raw) return "";
+//   if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+//     return raw;
+//   }
+//
+//   const display = toDisplayBirthday(raw);
+//   const m = display.match(/^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/(\d{4})$/);
+//   if (m) {
+//     const [, mm, dd, yyyy] = m;
+//     return `${yyyy}-${mm}-${dd}`;
+//   }
+//
+//   return raw;
+// };
 
 // Given the date string of the start time, formate the start date
 const formatProgramDate = (iso: string | null | undefined): string => {
@@ -116,6 +126,92 @@ const getFirebaseErrorCode = (error: unknown): string | undefined => {
   return undefined;
 };
 
+const isPronounsQuestion = (question: Questions) =>
+  question.title.toLowerCase().includes("pronoun");
+
+const getPronounsFromFormResponse = (response: FormResponse | null): string => {
+  const pronounsQuestion = response?.questions.find(isPronounsQuestion);
+  const answer = pronounsQuestion?.answer;
+  return typeof answer === "string" ? answer : "";
+};
+
+type MatchableProfileResponse = {
+  title: string;
+  type: "text" | "slider";
+  answer: string | number;
+};
+
+export type MatchableProfileResponseForDisplay = MatchableProfileResponse;
+
+const getMatchableQuestions = (form: Form | null): Question[] => {
+  if (!form) return [];
+
+  return form.sections.flatMap((section) =>
+    section.questions.filter((question) => question.matchable),
+  );
+};
+
+const hasAnswer = (answer: string | number | undefined): answer is string | number => {
+  if (typeof answer === "number") return true;
+  return typeof answer === "string" && answer.trim().length > 0;
+};
+
+const buildMatchableProfileResponses = (
+  form: Form | null,
+  response: FormResponse | null,
+): MatchableProfileResponse[] => {
+  const answersByTitle = new Map<string, string | number>();
+  response?.questions.forEach((question) => {
+    answersByTitle.set(question.title, question.answer);
+  });
+
+  return getMatchableQuestions(form).flatMap((question) => {
+    const answer = answersByTitle.get(question.title);
+    if (!hasAnswer(answer)) return [];
+
+    return [
+      {
+        title: question.title,
+        type: question.type === "Slider" ? "slider" : "text",
+        answer,
+      },
+    ];
+  });
+};
+
+const updatePronounsFormResponse = async (
+  uid: string,
+  pronouns: string,
+): Promise<boolean> => {
+  const responseRef = doc(db, "FormResponse", uid);
+  const responseSnap = await getDoc(responseRef);
+
+  if (!responseSnap.exists()) {
+    return false;
+  }
+
+  const response = responseSnap.data() as FormResponse;
+  let updated = false;
+  const questions = response.questions.map((question) => {
+    if (!isPronounsQuestion(question)) {
+      return question;
+    }
+
+    updated = true;
+    return {
+      ...question,
+      answer: pronouns,
+    };
+  });
+
+  if (!updated) {
+    return false;
+  }
+
+  await updateDoc(responseRef, { questions });
+  return true;
+};
+
 const Profile = () => {
   const navigate = useNavigate();
   const { programState } = useAuth();
@@ -128,6 +224,12 @@ const Profile = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [logoutError, setLogoutError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [matchableResponses, setMatchableResponses] = useState<
+    MatchableProfileResponse[]
+  >([]);
+  const [matchMatchableResponses, setMatchMatchableResponses] = useState<
+    MatchableProfileResponse[]
+  >([]);
 
   const [showInterestsModal, setShowInterestsModal] = useState(false);
 
@@ -147,6 +249,8 @@ const Profile = () => {
     const unsubscribe = onAuthStateChanged(auth, async (fbUser) => {
       if (!fbUser) {
         setUser(null);
+        setMatchableResponses([]);
+        setMatchMatchableResponses([]);
         setLoading(false);
         return;
       }
@@ -177,6 +281,8 @@ const Profile = () => {
             matchInterests: "",
           };
           setUser(fallback);
+          setMatchableResponses([]);
+          setMatchMatchableResponses([]);
           setLoading(false);
           return;
         }
@@ -185,9 +291,32 @@ const Profile = () => {
         const addr = data.address ?? {};
         const status = data.type ?? "Participant";
         const isAdmin = String(status).toLowerCase() === "admin";
+        let pronouns = "";
+        let formResponse: FormResponse | null = null;
+        let registrationForm: Form | null = null;
+
+        if (!isAdmin) {
+          const formResponseRef = doc(db, "FormResponse", fbUser.uid);
+          const formResponseSnap = await getDoc(formResponseRef);
+          if (formResponseSnap.exists()) {
+            formResponse = formResponseSnap.data() as FormResponse;
+            pronouns = getPronounsFromFormResponse(formResponse);
+          }
+
+          const registrationFormRef = doc(db, "config", "registrationForm");
+          const registrationFormSnap = await getDoc(registrationFormRef);
+          registrationForm = registrationFormSnap.exists()
+            ? (registrationFormSnap.data() as Form)
+            : null;
+          setMatchableResponses(
+            buildMatchableProfileResponses(registrationForm, formResponse),
+          );
+        } else {
+          setMatchableResponses([]);
+          setMatchMatchableResponses([]);
+        }
 
         let matchName = "";
-        let matchInterests = "";
 
         if (!isAdmin) {
           try {
@@ -197,11 +326,15 @@ const Profile = () => {
               const partnerId = getPartnerId(firstMatch, fbUser.uid);
 
               const partnerRef = doc(db, "participants", partnerId);
-              const partnerSnap = await getDoc(partnerRef);
+              const partnerFormResponseRef = doc(db, "FormResponse", partnerId);
+              const [partnerSnap, partnerFormResponseSnap] = await Promise.all([
+                getDoc(partnerRef),
+                getDoc(partnerFormResponseRef),
+              ]);
+
               if (partnerSnap.exists()) {
                 const partnerData = partnerSnap.data() as ParticipantDoc & {
                   name?: string | null;
-                  freeResponse?: string | null;
                 };
                 matchName =
                   partnerData.displayName ??
@@ -209,12 +342,23 @@ const Profile = () => {
                   [partnerData.firstName, partnerData.lastName]
                     .filter(Boolean)
                     .join(" ");
-                matchInterests =
-                  partnerData.interests ?? partnerData.freeResponse ?? "";
               }
+
+              const partnerFormResponse = partnerFormResponseSnap.exists()
+                ? (partnerFormResponseSnap.data() as FormResponse)
+                : null;
+              setMatchMatchableResponses(
+                buildMatchableProfileResponses(
+                  registrationForm,
+                  partnerFormResponse,
+                ),
+              );
+            } else {
+              setMatchMatchableResponses([]);
             }
           } catch (matchErr) {
             console.error("Error fetching match info:", matchErr);
+            setMatchMatchableResponses([]);
           }
         }
 
@@ -222,20 +366,21 @@ const Profile = () => {
           uid: fbUser.uid,
           name: data.displayName ?? data.name ?? fbUser.displayName ?? "",
           email: data.email ?? fbUser.email ?? "",
-          pronouns: data.pronouns ?? "",
+          pronouns,
           phone: formatPhone(data.phoneNumber ?? ""),
-          birthday: toDisplayBirthday(data.dateOfBirth),
+          // birthday: toDisplayBirthday(data.dateOfBirth),
+          birthday: "",
           addressLine1: addr.line1 ?? "",
           addressCity: addr.city ?? "",
           addressState: addr.state ?? "",
           addressPostalCode: addr.postalCode ?? "",
           addressCountry: addr.country ?? "",
-          interests: data.interests ?? "",
+          interests: "",
           startDate: data.startDate ?? "",
           endDate: data.endDate ?? "",
           status,
           matchName,
-          matchInterests,
+          matchInterests: "",
         };
 
         setUser(profile);
@@ -261,6 +406,8 @@ const Profile = () => {
           matchInterests: "",
         };
         setUser(fallback);
+        setMatchableResponses([]);
+        setMatchMatchableResponses([]);
       } finally {
         setLoading(false);
       }
@@ -312,9 +459,9 @@ const Profile = () => {
         newErrors.phone = "Please enter a valid 10-digit phone number.";
       }
 
-      if (user.birthday && !dateRegex.test(user.birthday)) {
-        newErrors.birthday = "Invalid date format";
-      }
+      // if (user.birthday && !dateRegex.test(user.birthday)) {
+      //   newErrors.birthday = "Invalid date format";
+      // }
 
       if (!user.addressLine1.trim()) {
         newErrors.addressLine1 = "Street address cannot be empty";
@@ -346,14 +493,28 @@ const Profile = () => {
       return false;
     }
 
-    const displayBirthday = toDisplayBirthday(user.birthday);
-    const normalizedBirthday = toStorageBirthday(displayBirthday);
-
-    if (displayBirthday !== user.birthday) {
-      setUser({ ...user, birthday: displayBirthday });
-    }
+    // const displayBirthday = toDisplayBirthday(user.birthday);
+    // const normalizedBirthday = toStorageBirthday(displayBirthday);
+    //
+    // if (displayBirthday !== user.birthday) {
+    //   setUser({ ...user, birthday: displayBirthday });
+    // }
 
     try {
+      if (!isAdmin && editingField === "pronouns") {
+        const updatedPronouns = await updatePronounsFormResponse(
+          user.uid,
+          user.pronouns,
+        );
+
+        if (!updatedPronouns) {
+          setProfileSaveError(
+            "Could not find your pronouns response. Please contact an admin.",
+          );
+          return false;
+        }
+      }
+
       const userRef = doc(db, "participants", user.uid);
 
       const baseUpdate = {
@@ -363,10 +524,8 @@ const Profile = () => {
       const participantUpdate = isAdmin
         ? {}
         : {
-            pronouns: user.pronouns,
             phoneNumber: stripPhone(user.phone),
-            dateOfBirth: normalizedBirthday,
-            interests: user.interests,
+            // dateOfBirth: normalizedBirthday,
             address: {
               line1: user.addressLine1,
               city: user.addressCity,
@@ -535,7 +694,7 @@ const Profile = () => {
         { label: "E-mail", name: "email", value: user.email, editable: false },
         { label: "Pronouns", name: "pronouns", value: user.pronouns, editable: true },
         { label: "Phone Number", name: "phone", value: user.phone, editable: true },
-        { label: "Birthday", name: "birthday", value: user.birthday, editable: true },
+        // { label: "Birthday", name: "birthday", value: user.birthday, editable: true },
         {
           label: "Street Address",
           name: "addressLine1",
@@ -560,6 +719,7 @@ const Profile = () => {
 
   const isEditingPersonalField =
     isEditing && personalFields.some((f) => f.name === editingField && f.editable);
+  const shouldShowMatchCard = !isAdmin && programState?.matches_final;
 
   return (
     <div className={styles.page}>
@@ -572,7 +732,7 @@ const Profile = () => {
             <span className={styles.statusTag}>{user.status}</span>
           </div>
 
-          {!isAdmin && (
+          {shouldShowMatchCard && (
             <div className={styles.infoCard}>
               <h3>Your Match</h3>
               <div className={styles.matchCircle}></div>
@@ -643,9 +803,9 @@ const Profile = () => {
                       name={field.name}
                       value={user[field.name as keyof UserProfile] as string}
                       onChange={handleChange}
-                      placeholder={
-                        field.name === "birthday" ? "MM/DD/YYYY" : undefined
-                      }
+                      // placeholder={
+                      //   field.name === "birthday" ? "MM/DD/YYYY" : undefined
+                      // }
                       autoFocus
                       className={styles.input}
                     />
@@ -692,14 +852,40 @@ const Profile = () => {
           {!isAdmin && (
             <div className={styles.infoSection}>
               <h3 className={styles.sectionTitle}>About Me</h3>
-              <div className={styles.fieldBox}>
-                <div className={styles.boxContent}>
-                  <div className={styles.boxHeader}>
-                    <span className={styles.boxLabel}>Interests</span>
-                  </div>
-                  <span className={styles.boxValue}>{user.interests}</span>
+              {matchableResponses.length > 0 ? (
+                <div className={styles.matchableResponses}>
+                  {matchableResponses.map((response) => (
+                    <article
+                      key={response.title}
+                      className={styles.matchableResponseCard}
+                    >
+                      <div className={styles.matchableResponseHeader}>
+                        <h4 className={styles.matchableQuestion}>
+                          {response.title}
+                        </h4>
+                      </div>
+
+                      {response.type === "slider" ? (
+                        <div className={styles.sliderResponse}>
+                          <span className={styles.sliderValue}>
+                            {response.answer}
+                          </span>
+                        </div>
+                      ) : (
+                        <textarea
+                          className={styles.matchableTextResponse}
+                          value={String(response.answer)}
+                          readOnly
+                        />
+                      )}
+                    </article>
+                  ))}
                 </div>
-              </div>
+              ) : (
+                <div className={styles.emptyMatchableResponses}>
+                  <span>No matchable responses available.</span>
+                </div>
+              )}
             </div>
           )}
 
@@ -819,7 +1005,7 @@ const Profile = () => {
         <MatchInterestsModal
           open={showInterestsModal}
           matchName={user.matchName}
-          matchInterests={user.matchInterests}
+          matchableResponses={matchMatchableResponses}
           onClose={() => setShowInterestsModal(false)}
         />
       )}

--- a/src/pages/Profile/components/MatchInterestsModal/MatchInterestsModal.tsx
+++ b/src/pages/Profile/components/MatchInterestsModal/MatchInterestsModal.tsx
@@ -1,19 +1,31 @@
 import React from "react";
 import styles from "../../Profile.module.css";
+import type { MatchableProfileResponseForDisplay } from "../../Profile";
 
 interface MatchInterestsModalProps {
   open: boolean;
   matchName?: string;
-  matchInterests?: string;
+  matchableResponses: MatchableProfileResponseForDisplay[];
   onClose: () => void;
 }
 
 const MatchInterestsModal: React.FC<MatchInterestsModalProps> = ({
   open,
   matchName,
-  matchInterests,
+  matchableResponses,
   onClose,
 }) => {
+  React.useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
   if (!open) return null;
 
   const handleBackdropClick = () => {
@@ -26,11 +38,6 @@ const MatchInterestsModal: React.FC<MatchInterestsModalProps> = ({
 
   const displayName =
     matchName && matchName.trim().length > 0 ? matchName : "Your match";
-
-  const displayInterests =
-    matchInterests && matchInterests.trim().length > 0
-      ? matchInterests
-      : "No interests response available.";
 
   return (
     <div className={styles.modalBackdrop} onClick={handleBackdropClick}>
@@ -47,7 +54,40 @@ const MatchInterestsModal: React.FC<MatchInterestsModalProps> = ({
         </div>
 
         <div className={styles.modalBody}>
-          <p>{displayInterests}</p>
+          {matchableResponses.length > 0 ? (
+            <div className={styles.matchableResponses}>
+              {matchableResponses.map((response) => (
+                <article
+                  key={response.title}
+                  className={styles.matchableResponseCard}
+                >
+                  <div className={styles.matchableResponseHeader}>
+                    <h4 className={styles.matchableQuestion}>
+                      {response.title}
+                    </h4>
+                  </div>
+
+                  {response.type === "slider" ? (
+                    <div className={styles.sliderResponse}>
+                      <span className={styles.sliderValue}>
+                        {response.answer}
+                      </span>
+                    </div>
+                  ) : (
+                    <textarea
+                      className={styles.matchableTextResponse}
+                      value={String(response.answer)}
+                      readOnly
+                    />
+                  )}
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className={styles.emptyMatchableResponses}>
+              <span>No matchable responses available.</span>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/Rematching/Rematching.module.css
+++ b/src/pages/Rematching/Rematching.module.css
@@ -176,6 +176,19 @@
     font-style: italic;
 }
 
+.lockedState {
+    width: min(640px, 100%);
+    margin: 8rem auto 0;
+    background: #ffffff;
+    color: #0f6bb1;
+    border-radius: 1rem;
+    padding: 2rem;
+    box-shadow: 0 8px 24px rgba(15, 107, 177, 0.15);
+    text-align: center;
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
 /* match details column */
 
 .matchContainer {

--- a/src/pages/Rematching/Rematching.tsx
+++ b/src/pages/Rematching/Rematching.tsx
@@ -16,6 +16,7 @@ import {
 } from "firebase/firestore";
 import { auth, db, computeMatchScore, getUser } from "../../firebase";
 import type { Form, Question, RematchingParticipant } from "../../types";
+import { useAuth } from "../../auth/AuthProvider";
 
 export type { RematchingParticipant } from "../../types";
 
@@ -110,6 +111,7 @@ const getParticipantPronouns = (
 
 export default function Rematching() {
   const navigate = useNavigate();
+  const { programState, programStateLoading } = useAuth();
   const [students, setStudents] = useState<RematchingParticipant[]>([]);
   const [adults, setAdults] = useState<RematchingParticipant[]>([]);
   const [approvedCount, setApprovedCount] = useState<number>(0);
@@ -550,6 +552,36 @@ export default function Rematching() {
   };
 
   const isMatchButtonDisabled = !selectedStudent || !selectedAdult || saving;
+
+  if (programStateLoading) {
+    return (
+      <div className={`${layoutStyles.page} ${styles.rematchingPage}`}>
+        <div className={`${layoutStyles.surface} ${styles.rematchingSurface}`}>
+          <div className={styles.loadingState}>Loading...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (programState?.matches_final) {
+    return (
+      <div className={`${layoutStyles.page} ${styles.rematchingPage}`}>
+        <div className={`${layoutStyles.surface} ${styles.rematchingSurface}`}>
+          <button
+            type="button"
+            className={styles.backButton}
+            onClick={() => navigate("/admin/main")}
+            aria-label="Back to PreProgram"
+          >
+            ←
+          </button>
+          <div className={styles.lockedState}>
+            Matches are locked. Unlock matches before manually rematching.
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={`${layoutStyles.page} ${styles.rematchingPage}`}>

--- a/src/pages/Waiting/Waiting.module.css
+++ b/src/pages/Waiting/Waiting.module.css
@@ -114,6 +114,7 @@
 
 .matchInfoCard {
     width: 100%;
+    box-sizing: border-box;
     background: #ffffff;
     border-radius: 32px;
     padding: clamp(1.5rem, 4vw, 2.75rem);

--- a/src/services/programState.ts
+++ b/src/services/programState.ts
@@ -48,3 +48,9 @@ export async function finalizeMatches() {
   });
 }
 
+export async function unfinalizeMatches() {
+  await updateDoc(programStateRef, {
+    matches_final: false,
+    updatedAt: serverTimestamp(),
+  });
+}


### PR DESCRIPTION
Participant profile page:
- Hide "Your Match" when matches aren't finalized
- Added user and partner interests

User dash:
- Added date ranges
- Disabled submission for future weeks
- Added color coding

Admin matching:
- Make Finalize Matches toggleable
- When matches final, disable Create match, manual rematch, and match status dropdowns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added week date labels and submission status tracking to the dashboard
  * Introduced current week indicator in week selector
  * Added match unlock functionality in admin controls
  * Profile page now displays matchable form responses instead of static interests
  * Matches locked state prevents access to rematching workflows when finalized
  * Background scroll is now locked when modals open

* **UI/UX Improvements**
  * Enhanced visual states for submitted and missing weeks
  * Refined sizing and styling across dashboard, profile, and admin pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->